### PR TITLE
Small doc improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,7 @@ A tiny (~100 line) shell script that manages ephemeral Postgres databases.
 
 # To remove your database and its configuration.
 ./pglite rm
+
+# To display your current database connection string
+./pglite url
 ```

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ A tiny (~100 line) shell script that manages ephemeral Postgres databases.
 # To remove your database and its configuration.
 ./pglite rm
 
-# To display your current database connection string
+# To display your current database connection string.
 ./pglite url
 
-# To simply connect to your database
-psq -d `./pglite url`
+# To simply connect to your database.
+psql -d `./pglite url`
 ```

--- a/README.md
+++ b/README.md
@@ -12,5 +12,7 @@ A tiny (~100 line) shell script that manages ephemeral Postgres databases.
 
 # The start/stop/status family of commands are passed directly to pg_ctl.
 ./pglite start|stop|status
-```
 
+# To remove your database and its configuration.
+./pglite rm
+```

--- a/README.md
+++ b/README.md
@@ -18,4 +18,7 @@ A tiny (~100 line) shell script that manages ephemeral Postgres databases.
 
 # To display your current database connection string
 ./pglite url
+
+# To simply connect to your database
+psq -d `./pglite url`
 ```

--- a/pglite
+++ b/pglite
@@ -7,7 +7,7 @@ cat <<USAGE
         pglite url
         pglite start|stop|status
         pglite connect
-        pglite clean
+        pglite rm
 
   Creates and manages the lifecycle of a Postgres database, using the system
   server installation.


### PR DESCRIPTION
- cleaning the confusing "rm/clean" in help text,
- tips in the README on how to use the "url" command.
