### PR TITLE
fix connect command behavior when calling on already running instance

### DIFF
--- a/pglite
+++ b/pglite
@@ -113,8 +113,12 @@ function setup {
 }
 
 function connect {
-  is_running || ctl start -w
-  trap finalize EXIT
+  if ! is_running; then
+      ctl start -w
+      trap finalize EXIT
+  else
+      load_personality
+  fi
   sql "$@"
 }
 

--- a/pglite
+++ b/pglite
@@ -113,11 +113,11 @@ function setup {
 }
 
 function connect {
-  if ! is_running; then
-      ctl start -w
-      trap finalize EXIT
-  else
-      load_personality
+  load_personality
+  if ! is_running
+  then
+    ctl start -w
+    trap finalize EXIT
   fi
   sql "$@"
 }


### PR DESCRIPTION
- should not stop the instance on exit
- call load_personality explicitly because the only ctl call made via
  is_running is done in a subshell
